### PR TITLE
Add example PrestaShop admin module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# admin
+# PrestaShop Admin Module Demo
+
+This repository contains an example PrestaShop module that registers a modern
+Symfony-based admin controller.
+
+```
+modules/
+└── my-module/
+    ├── my-module.php
+    ├── composer.json
+    ├── config/routes.yml
+    ├── src/Controller/DemoController.php
+    └── templates/admin/demo.html.twig
+```
+
+The controller is accessible under the route `your_route_name` and renders a
+simple page using the PrestaShop UI Kit.
+

--- a/modules/my-module/composer.json
+++ b/modules/my-module/composer.json
@@ -1,0 +1,13 @@
+{
+  "name": "you/my-module",
+  "description": "Example PrestaShop module with admin controller",
+  "autoload": {
+    "psr-4": {
+      "MyModule\\Controller\\": "src/Controller/"
+    }
+  },
+  "config": {
+    "prepend-autoloader": false
+  },
+  "type": "prestashop-module"
+}

--- a/modules/my-module/config/routes.yml
+++ b/modules/my-module/config/routes.yml
@@ -1,0 +1,5 @@
+your_route_name:
+  path: my-module/demo
+  methods: [GET]
+  defaults:
+    _controller: 'MyModule\\Controller\\DemoController::demoAction'

--- a/modules/my-module/my-module.php
+++ b/modules/my-module/my-module.php
@@ -1,0 +1,34 @@
+<?php
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+
+class My_Module extends Module
+{
+    public function __construct()
+    {
+        $this->name = 'my-module';
+        $this->version = '1.0.0';
+        $this->author = 'You';
+        $this->tab = 'administration';
+        $this->bootstrap = true;
+        parent::__construct();
+
+        $this->displayName = $this->l('My Module');
+        $this->description = $this->l('Example module demonstrating an admin controller.');
+    }
+
+    public function install()
+    {
+        return parent::install();
+    }
+
+    public function generateControllerURI()
+    {
+        $router = SymfonyContainer::getInstance()->get('router');
+        return $router->generate('your_route_name');
+    }
+}
+

--- a/modules/my-module/src/Controller/DemoController.php
+++ b/modules/my-module/src/Controller/DemoController.php
@@ -1,0 +1,22 @@
+<?php
+namespace MyModule\Controller;
+
+use Doctrine\Common\Cache\CacheProvider;
+use PrestaShopBundle\Controller\Admin\FrameworkBundleAdminController;
+use Symfony\Component\HttpFoundation\Response;
+
+class DemoController extends FrameworkBundleAdminController
+{
+    /** @var CacheProvider */
+    private $cache;
+
+    public function __construct(CacheProvider $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    public function demoAction(): Response
+    {
+        return $this->render('@Modules/my-module/templates/admin/demo.html.twig');
+    }
+}

--- a/modules/my-module/templates/admin/demo.html.twig
+++ b/modules/my-module/templates/admin/demo.html.twig
@@ -1,0 +1,10 @@
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  <div class="card">
+    <div class="card-body">
+      <h3>Demo Controller</h3>
+      <p>This is a demo admin controller rendered from a module.</p>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create a sample PrestaShop module `my-module`
- add a Symfony controller with route configuration
- include autoloading via composer.json
- provide a Twig template
- document usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a4de575508326854bbfd1ee411f16