### PR TITLE
Implement admin tab registration via $tabs property

### DIFF
--- a/modules/my-module/config/routes.yml
+++ b/modules/my-module/config/routes.yml
@@ -3,3 +3,4 @@ your_route_name:
   methods: [GET]
   defaults:
     _controller: 'MyModule\\Controller\\DemoController::demoAction'
+    _legacy_controller: AdminMyModuleDemo

--- a/modules/my-module/my-module.php
+++ b/modules/my-module/my-module.php
@@ -4,9 +4,15 @@ if (!defined('_PS_VERSION_')) {
 }
 
 use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+use Language;
 
 class My_Module extends Module
 {
+    /**
+     * @var array
+     */
+    public $tabs = [];
+
     public function __construct()
     {
         $this->name = 'my-module';
@@ -18,6 +24,22 @@ class My_Module extends Module
 
         $this->displayName = $this->l('My Module');
         $this->description = $this->l('Example module demonstrating an admin controller.');
+
+        $tabNames = [];
+        foreach (Language::getLanguages(true) as $lang) {
+            $tabNames[$lang['locale']] = $this->trans('Demo', [], 'Modules.MyModule.Admin', $lang['locale']);
+        }
+        $this->tabs = [
+            [
+                'route_name' => 'your_route_name',
+                'class_name' => 'AdminMyModuleDemo',
+                'visible' => true,
+                'name' => $tabNames,
+                'parent_class_name' => 'AdminParentModulesSf',
+                'wording' => 'Demo',
+                'wording_domain' => 'Modules.MyModule.Admin',
+            ],
+        ];
     }
 
     public function install()


### PR DESCRIPTION
## Summary
- register a back-office tab for the demo controller using `$tabs`
- add `_legacy_controller` to routing for the new tab

## Testing
- `php -l modules/my-module/my-module.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4ef0bb1483268b07846f7e9f40c3