### PR TITLE
Add admin route helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,17 @@ modules/
 The controller is accessible under the route `your_route_name` and renders a
 simple page using the PrestaShop UI Kit.
 
+### Generating Symfony routes
+
+The module includes a helper method that demonstrates how to generate a Symfony
+route from a legacy context using PrestaShop's `Link` component:
+
+```php
+public function generateAdminRoute(string $route, array $params = [])
+{
+    $link = new \Link();
+
+    return $link->getAdminLink('AdminModules', true, array_merge(['route' => $route], $params));
+}
+```
+

--- a/modules/my-module/my-module.php
+++ b/modules/my-module/my-module.php
@@ -30,5 +30,20 @@ class My_Module extends Module
         $router = SymfonyContainer::getInstance()->get('router');
         return $router->generate('your_route_name');
     }
+
+    /**
+     * Demonstrates generating a Symfony route using the Link helper.
+     *
+     * @param string $route Symfony route name
+     * @param array $params Route parameters
+     *
+     * @return string
+     */
+    public function generateAdminRoute(string $route, array $params = [])
+    {
+        $link = new \Link();
+
+        return $link->getAdminLink('AdminModules', true, array_merge(['route' => $route], $params));
+    }
 }
 


### PR DESCRIPTION
## Summary
- add `generateAdminRoute` method for Link-based route generation
- document new helper in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a4f1d41ec8326819e6cda4c35c2ac