### PR TITLE
Fix class scope for module

### DIFF
--- a/awvisualmerchandising.php
+++ b/awvisualmerchandising.php
@@ -61,7 +61,7 @@ public $tabs = [
 
         $this->ps_versions_compliancy = ['min' => '8.0.0', 'max' => _PS_VERSION_];
     }
-}
+
 public function install()
 {
     include dirname(__FILE__) . '/sql/install.php';


### PR DESCRIPTION
## Summary
- fix closing bracket so class extends to include install and other methods

## Testing
- `php -l awvisualmerchandising.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a53bae07483268c1f0d87d9177c08